### PR TITLE
Properly comply with PHPCS naming conventions

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -44,7 +44,7 @@
       <property name="spacesCountAroundEqualsSign" value="0" />
     </properties>
   </rule>
-  <rule ref="src/Sniffs/StrictTypes/ExplainStrictTypesSniff.php">
+  <rule ref="src/Exercism/Sniffs/StrictTypes/ExplainStrictTypesSniff.php">
     <exclude-pattern>*/*Test\.php</exclude-pattern>
     <exclude-pattern>*/.meta/*\.php</exclude-pattern>
     <exclude-pattern>src/*</exclude-pattern>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,7 +34,7 @@
     <exclude-pattern>*/concept/city-office/*</exclude-pattern>
     <exclude-pattern>*/concept/windowing-system/*</exclude-pattern>
   </rule>
-  <rule ref="vendor/slevomat/coding-standard/SlevomatCodingStandard/Sniffs/TypeHints/DeclareStrictTypesSniff.php">
+  <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
     <exclude-pattern>*/.meta/*\.php</exclude-pattern>
     <exclude-pattern>*/concept/*</exclude-pattern>
     <exclude-pattern>*/hello-world/*</exclude-pattern>

--- a/src/Exercism/Sniffs/StrictTypes/ExplainStrictTypesSniff.php
+++ b/src/Exercism/Sniffs/StrictTypes/ExplainStrictTypesSniff.php
@@ -57,7 +57,7 @@ EOT;
             $phpcsFile->addFixableError(
                 'Missing explanation of declaration of strict types.',
                 $stackPtr - 1,
-                self::class
+                'Missing'
             );
             $this->fix();
         }

--- a/src/Exercism/Sniffs/StrictTypes/ExplainStrictTypesSniff.php
+++ b/src/Exercism/Sniffs/StrictTypes/ExplainStrictTypesSniff.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Exercism\Sniffs\StrictTypes;
+namespace Exercism\Exercism\Sniffs\StrictTypes;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Fixer;


### PR DESCRIPTION
:point_right: Note: the first commit is the only one _necessary_ to fix the issue you were experiencing. The second and third commits are "best practice" fixes as I had the repo open now anyway.


### Properly comply with PHPCS naming conventions

Note: I've not changed the `composer.json` file, but it could also be considered to leave the sniff namespace the same and to change the `"Exercism\\": "src",` config in the `composer.json` file to `"Exercism\\": "src\\Exercism",`.

### ExplainStrictTypesSniff: use proper error code

The class name is already translated to a sniff name, so no need to duplicate it. Also not a good idea to use backslashes in the error code as that makes configuration in the XML file more fiddly.

### PHPCS config: include sniff from installed standard by name 